### PR TITLE
Fix optional tags binding in BountyRepository to use default value wh…

### DIFF
--- a/backend/database/src/repository/bounty_repository.rs
+++ b/backend/database/src/repository/bounty_repository.rs
@@ -79,7 +79,7 @@ impl BountyRepository {
         .bind(cover_photo)
         .bind(category)
         .bind(difficulty)
-        .bind(tags)
+        .bind(tags.unwrap_or_default())
         .bind(reward_amount)
         .bind(reward_currency)
         .bind(deadline)


### PR DESCRIPTION
…en not provided